### PR TITLE
#9: added change set disabling based on parameter substitution, the e…

### DIFF
--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/MigrationChangelog.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/MigrationChangelog.kt
@@ -40,8 +40,8 @@ internal class MigrationChangelog(private val migrationUserId: UUID, private val
                     if (get(i).hash() != it) {
                         if (!correctHashes) {
                             throw MigrationException(
-                                    "Invalid hash expected: $it (remote) got ${get(i).hash()} (local) in migration: ${get(
-                                            i).id}")
+                                    "Invalid hash expected: $it (remote) " +
+                                        "got ${get(i).hash()} (local) in migration: ${get(i).id}")
                         }
                         replaceHash(it, get(i).hash)
                         LOG.warn("Replaced hash: $it with ${get(i).hash} for migration ${get(i).id}")

--- a/src/main/kotlin/de/klg71/keycloakmigration/changeControl/MigrationChangelog.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/changeControl/MigrationChangelog.kt
@@ -30,7 +30,11 @@ internal class MigrationChangelog(private val migrationUserId: UUID, private val
         val changeHashes = getMigrationsHashes()
 
         return changes
-            .filter { it.enabled == null || it.enabled.toBoolean() }
+            .filter {
+                val enabled = it.enabled.toBoolean()
+                if (!enabled) LOG.info("Skipping disabled migration: ${it.id}")
+                enabled
+            }
             .apply {
                 changeHashes.forEachIndexed { i, it ->
                     if (get(i).hash() != it) {

--- a/src/main/kotlin/de/klg71/keycloakmigration/model/ChangeSet.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/model/ChangeSet.kt
@@ -8,7 +8,8 @@ data class ChangeSet(val id: String,
                      val changes: List<Action>,
                      val realm: String? = null,
                      @JsonIgnore
-                     var path: String = "") {
+                     var path: String = "",
+                     val enabled: String? = null) {
 
     lateinit var hash: String
 

--- a/src/main/kotlin/de/klg71/keycloakmigration/model/ChangeSet.kt
+++ b/src/main/kotlin/de/klg71/keycloakmigration/model/ChangeSet.kt
@@ -9,7 +9,7 @@ data class ChangeSet(val id: String,
                      val realm: String? = null,
                      @JsonIgnore
                      var path: String = "",
-                     val enabled: String? = null) {
+                     val enabled: String = "true") {
 
     lateinit var hash: String
 

--- a/src/test/kotlin/de/klg71/keycloakmigration/changeControl/MigrationChangelogTest.kt
+++ b/src/test/kotlin/de/klg71/keycloakmigration/changeControl/MigrationChangelogTest.kt
@@ -67,7 +67,7 @@ class MigrationChangelogTest : KoinTest {
         val user = mock<User> { }
 
         whenever(client.user(migrationUserId, realm)).thenReturn(user)
-        val result = changelog.changesTodo(listOf(mock { }, mock {}))
+        val result = changelog.changesTodo(listOf(mockChangeSet(), mockChangeSet()))
 
         verify(client).user(migrationUserId, realm)
 
@@ -84,7 +84,7 @@ class MigrationChangelogTest : KoinTest {
         }
 
         whenever(client.user(migrationUserId, realm)).thenReturn(user)
-        val result = changelog.changesTodo(listOf(mock { }, mock {}))
+        val result = changelog.changesTodo(listOf(mockChangeSet(), mockChangeSet()))
 
         verify(client).user(migrationUserId, realm)
 
@@ -101,7 +101,7 @@ class MigrationChangelogTest : KoinTest {
         }
 
         whenever(client.user(migrationUserId, realm)).thenReturn(user)
-        val result = changelog.changesTodo(listOf(mock { }, mock {}))
+        val result = changelog.changesTodo(listOf(mockChangeSet(), mockChangeSet()))
 
         verify(client).user(migrationUserId, realm)
 
@@ -118,7 +118,7 @@ class MigrationChangelogTest : KoinTest {
         }
 
         whenever(client.user(migrationUserId, realm)).thenReturn(user)
-        val result = changelog.changesTodo(listOf(mock { }, mock {}))
+        val result = changelog.changesTodo(listOf(mockChangeSet(), mockChangeSet()))
 
         verify(client).user(migrationUserId, realm)
 
@@ -134,10 +134,7 @@ class MigrationChangelogTest : KoinTest {
             on { attributes } doReturn mapOf(migrationAttributeName to listOf("rightHash"))
         }
 
-        val changeSet = mock<ChangeSet> {
-            on { hash() } doReturn "wrongHash"
-            on { id } doReturn "testId"
-        }
+        val changeSet = mockChangeSet(testHash = "wrongHash", testId = "testId")
 
         whenever(client.user(migrationUserId, realm)).thenReturn(user)
         assertThatThrownBy { changelog.changesTodo(listOf(changeSet)) }
@@ -155,10 +152,7 @@ class MigrationChangelogTest : KoinTest {
             on { attributes } doReturn mapOf(migrationAttributeName to listOf("rightHash"))
         }
 
-
-        val changeSet = mock<ChangeSet> {
-            on { hash() } doReturn "rightHash"
-        }
+        val changeSet = mockChangeSet(testHash = "rightHash")
 
         whenever(client.user(migrationUserId, realm)).thenReturn(user)
         val result = changelog.changesTodo(listOf(changeSet))
@@ -176,16 +170,9 @@ class MigrationChangelogTest : KoinTest {
         }
 
 
-        val changeSetBefore = mock<ChangeSet> {
-            on { hash() } doReturn "hashBefore"
-        }
-        val disabledChangeSet = mock<ChangeSet> {
-            on { enabled } doReturn "false"
-        }
-        val changeSetAfter = mock<ChangeSet> {
-            on { hash() } doReturn "hashAfter"
-            on { enabled } doReturn "true"
-        }
+        val changeSetBefore = mockChangeSet(testHash = "hashBefore")
+        val disabledChangeSet = mockChangeSet(isEnabled = false)
+        val changeSetAfter = mockChangeSet(testHash = "hashAfter")
 
         whenever(client.user(migrationUserId, realm)).thenReturn(user)
         val result = changelog.changesTodo(listOf(changeSetBefore, disabledChangeSet, changeSetAfter))
@@ -202,19 +189,10 @@ class MigrationChangelogTest : KoinTest {
             on { attributes } doReturn mapOf(migrationAttributeName to listOf("hashBefore", "hashAfter"))
         }
 
-        val changeSetBefore = mock<ChangeSet> {
-            on { hash() } doReturn "hashBefore"
-        }
-        val disabledChangeSet = mock<ChangeSet> {
-            on { enabled } doReturn "false"
-        }
-        val changeSetAfter = mock<ChangeSet> {
-            on { hash() } doReturn "hashAfter"
-            on { enabled } doReturn "true"
-        }
-        val newChangeSet = mock<ChangeSet> {
-            on { hash() } doReturn "hashNew"
-        }
+        val changeSetBefore = mockChangeSet(testHash = "hashBefore")
+        val disabledChangeSet = mockChangeSet(isEnabled = false)
+        val changeSetAfter = mockChangeSet(testHash = "hashAfter", isEnabled = true)
+        val newChangeSet = mockChangeSet(testHash = "hashNew")
 
         whenever(client.user(migrationUserId, realm)).thenReturn(user)
         val result = changelog.changesTodo(listOf(changeSetBefore, disabledChangeSet, changeSetAfter, newChangeSet))
@@ -230,9 +208,7 @@ class MigrationChangelogTest : KoinTest {
         val userBefore = User(migrationUserId, 0L, "test", true, true, null, 0L, false, UserAccess(false, false, false, false, false), emptyList(), emptyList(), null, "test", null, null)
 
 
-        val changeSet = mock<ChangeSet> {
-            on { hash() } doReturn "hash"
-        }
+        val changeSet = mockChangeSet(testHash = "hash")
         val userAfter = User(migrationUserId, 0L, "test", true, true, mapOf(migrationAttributeName to listOf("hash")), 0L, false, UserAccess(false, false, false, false, false), emptyList(), emptyList(), null, "test", null, null)
 
         whenever(client.user(migrationUserId, realm)).thenReturn(userBefore)
@@ -248,9 +224,7 @@ class MigrationChangelogTest : KoinTest {
         val userBefore = User(migrationUserId, 0L, "test", true, true, mapOf(migrationAttributeName to emptyList()), 0L, false, UserAccess(false, false, false, false, false), emptyList(), emptyList(), null, "test", null, null)
 
 
-        val changeSet = mock<ChangeSet> {
-            on { hash() } doReturn "hash"
-        }
+        val changeSet = mockChangeSet(testHash = "hash")
         val userAfter = User(migrationUserId, 0L, "test", true, true, mapOf(migrationAttributeName to listOf("hash")), 0L, false, UserAccess(false, false, false, false, false), emptyList(), emptyList(), null, "test", null, null)
 
         whenever(client.user(migrationUserId, realm)).thenReturn(userBefore)
@@ -266,9 +240,7 @@ class MigrationChangelogTest : KoinTest {
         val userBefore = User(migrationUserId, 0L, "test", true, true, mapOf(migrationAttributeName to listOf("hashBefore")), 0L, false, UserAccess(false, false, false, false, false), emptyList(), emptyList(), null, "test", null, null)
 
 
-        val changeSet = mock<ChangeSet> {
-            on { hash() } doReturn "hash"
-        }
+        val changeSet = mockChangeSet(testHash = "hash")
         val userAfter = User(migrationUserId, 0L, "test", true, true, mapOf(migrationAttributeName to listOf("hashBefore","hash")), 0L, false, UserAccess(false, false, false, false, false), emptyList(), emptyList(), null, "test", null, null)
 
         whenever(client.user(migrationUserId, realm)).thenReturn(userBefore)
@@ -276,5 +248,10 @@ class MigrationChangelogTest : KoinTest {
         verify(client).updateUser(eq(migrationUserId), eq(userAfter), eq(realm))
     }
 
-
+    private fun mockChangeSet(testHash: String = "", isEnabled: Boolean = true, testId: String = ""): ChangeSet =
+        mock {
+            on { enabled } doReturn isEnabled.toString()
+            on { hash() } doReturn testHash
+            on { id } doReturn testId
+        }
 }

--- a/src/test/resources/changesets/24_disabled_change_set.yml
+++ b/src/test/resources/changesets/24_disabled_change_set.yml
@@ -1,0 +1,7 @@
+id: diabled_change_set
+author: sideisra
+realm: integ-test
+enabled: ${IS_TEST_ENV}
+changes:
+  - addRole:
+      name: disabledTest

--- a/src/test/resources/keycloak-changelog.yml
+++ b/src/test/resources/keycloak-changelog.yml
@@ -21,4 +21,4 @@ includes:
 - path: changesets/21_update_realm_action.yml
 - path: changesets/22_add_client_mappers.yml
 - path: changesets/23_add_user_federation_mappers.yml
-
+- path: changesets/24_disabled_change_set.yml


### PR DESCRIPTION
…nabled attribute of a change set can be set to any string (including substituted parameters), this string will then be interpreted as boolean when executing the change sets and thus disabling the change set when the attribute is set to the string "false"